### PR TITLE
zkagi template: added shm size

### DIFF
--- a/zkagi.yaml
+++ b/zkagi.yaml
@@ -25,6 +25,7 @@ connect:
             arch: linux/amd64
             restart: unless-stopped
             privileged: true
+            shm-size: 2147483648
             environment:
                 - <- `walletAddress=${walletAddress}`
                 - <- `nodeIP=${nodeIP}`


### PR DESCRIPTION
This warning tells to increase shm size

```
2024-07-26 16:21:24,798 WARNING services.py:1996 -- WARNING: The object store is using /tmp instead of /dev/shm because /dev/shm has only 65536000 bytes available. This will harm performance! You may be able to free up space by deleting files in /dev/shm. If you are inside a Docker container, you can increase /dev/shm size by passing '--shm-size=0.31gb' to 'docker run' (or add it to the run_options list in a Ray cluster config). Make sure to set this to more than 30% of available RAM.
```

I added optional parameter on Sonaric size to allow to configure this parameter

there is issue with integer variable, so currently hardcoded to 2GB