### PR TITLE
zkagi: required walletAddress variable 

### DIFF
--- a/zkagi.yaml
+++ b/zkagi.yaml
@@ -77,7 +77,8 @@ connect:
         walletAddress:
             description: "wallet address"
             type: string
-            value: "49W2pMuoBt58EDcipp6CtqASMGsxNuUEfC3zqo99eR9j"
+            required: true
+            value: ""
         nodeIP:
             type: string
             value: <- ip-address-public


### PR DESCRIPTION
we can pass it in runtime like `sonaric run -s walletAddress=49W2pMuoBt58EDcipp6CtqASMGsxNuUEfC3zqo99eR9j zkagi/connect`