### PR TITLE
eigen: remove initial empty value for keys variables

### DIFF
--- a/eigen-layer/eigen.yaml
+++ b/eigen-layer/eigen.yaml
@@ -104,12 +104,10 @@ da-node-base:
             description: "bls private key password"
             type: string
             required: true
-            value: ""
         ecdsa-key-password:
             description: "ecdsa private key password"
             type: string
             required: true
-            value: ""
         test-mode:
             description: "Whether to run as test mode"
             type: bool


### PR DESCRIPTION
removed `value: ""` for bls and ecdsa keys to force setting non-empty values during run